### PR TITLE
POC for long-form-2 with Validation State UX Approach 1

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from "@angular/core";
 import { Route, RouterModule } from "@angular/router";
 import { LongForm1Component } from "./long-form-1/long-form-1.component";
 import { LongForm2Component } from "./long-form-2/long-form-2.component";
+import { FormWizardComponent } from "./form-wizard/form-wizard.component.";
 
 @Component({
     selector: 'app-root',
@@ -14,6 +15,8 @@ import { LongForm2Component } from "./long-form-2/long-form-2.component";
           <a routerLink="/long-form-1" routerLinkActive="text-dark fw-bold">Long Form 1</a>
           <br />
           <a routerLink="/long-form-2" routerLinkActive="text-dark fw-bold">Long Form 2</a>
+          <br />
+          <a routerLink="/form-wizard" routerLinkActive="text-dark fw-bold">Form Wizard</a>
         </nav>
         <hr />
         <router-outlet />
@@ -31,6 +34,10 @@ import { LongForm2Component } from "./long-form-2/long-form-2.component";
     {
       path: 'long-form-2',
       component: LongForm2Component,
+    },
+    {
+      path: 'form-wizard',
+      component: FormWizardComponent,
     },
     {
       path: '',

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,5 +1,5 @@
 <div class="text-secondary">
-  <b>Profile Subform Status:</b>
+  <b>Subform Status:</b>
   <span
     [ngClass]="{
       'text-danger': form.touched && !form.valid,
@@ -8,7 +8,7 @@
   >
     {{ form.status }}
   </span>
-  @if (!form.valid) {{{ form.errors | json }}}
+  <!-- @if (!form.valid) {{{ form.errors | json }}} -->
   {{ form.touched ? 'touched' : 'untouched' }}
   {{ form.dirty ? 'dirty' : 'pristine' }}
   <button
@@ -18,11 +18,11 @@
   >
     Mark All Touched
   </button>
-  <button type="button" (click)="onUpdateValue()" class="btn btn-primary">
+  <!-- <button type="button" (click)="onUpdateValue()" class="btn btn-primary">
     Update Value and Validity
-  </button>
+  </button> -->
   <br />
-  <b>Profile Subform:</b> {{ form.value | json }}
+  <b>Subform Value:</b> {{ form.value | json }}
 </div>
 
 <div formGroupName="profile">

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -26,7 +26,7 @@
 </div>
 
 <div formGroupName="profile">
-  <div class="row">
+  <div class="row mt-3">
     <div class="col">
       <app-text-field-cva formControlName="first"> </app-text-field-cva>
     </div>
@@ -35,18 +35,35 @@
     </div>
   </div>
   <div class="row">
-    <div
-      class="col"
-      [ngClass]="{
-        'was-validated': genderControl && genderControl.touched
-      }"
-    >
-      <select formControlName="gender" class="form-select mb-3">
-        <option selected disabled value="">Select gender...</option>
+    <div class="col mb-3">
+      <label class="fw-bold">Gender</label>
+      <select formControlName="gender" class="form-select"
+        [ngClass]="{
+          'is-invalid': genderControl && 
+                        (genderControl!.touched || genderControl!.dirty) && 
+                        !genderControl!.valid,
+          'is-valid': genderControl && 
+                      (genderControl!.touched || genderControl!.dirty) && 
+                      genderControl!.valid,
+        }"
+      >
+        <option disabled value="">Select a gender...</option>
         <option *ngFor="let option of genderOptions" [value]="option">
           {{ option }}
         </option>
       </select>
+      <div
+        class="text-danger"
+        [ngClass]="
+          genderControl && 
+          genderControl!.touched && 
+          !genderControl!.valid 
+            ? 'visible' 
+            : 'invisible'
+        "
+      >
+        This field is required!
+      </div>
     </div>
   </div>
   <ng-container *ngIf="form.value?.gender === 'Other'">

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -2,8 +2,8 @@
   <b>Subform Status:</b>
   <span
     [ngClass]="{
-      'text-danger': form.touched && !form.valid,
-      'text-success': form.touched && form.valid
+      'text-danger': form.touched && !form.valid && !form.disabled,
+      'text-success': form.touched && form.valid && !form.disabled
     }"
   >
     {{ form.status }}
@@ -40,11 +40,11 @@
       <select formControlName="gender" class="form-select"
         [ngClass]="{
           'is-invalid': genderControl && 
-                        (genderControl!.touched || genderControl!.dirty) && 
-                        !genderControl!.valid,
+                        (genderControl.touched || genderControl.dirty) && 
+                        !genderControl.valid && !genderControl.disabled,
           'is-valid': genderControl && 
-                      (genderControl!.touched || genderControl!.dirty) && 
-                      genderControl!.valid,
+                      (genderControl.touched || genderControl.dirty) && 
+                      genderControl.valid && !genderControl.disabled,
         }"
       >
         <option disabled value="">Select a gender...</option>
@@ -56,8 +56,9 @@
         class="text-danger"
         [ngClass]="
           genderControl && 
-          genderControl!.touched && 
-          !genderControl!.valid 
+          genderControl.touched && 
+          !genderControl.valid &&
+          !genderControl.disabled
             ? 'visible' 
             : 'invisible'
         "

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -17,6 +17,13 @@ import {
 } from '@angular/forms';
 import { TextFieldCvaComponent } from '../text-field-cva/text-field-cva.component';
 
+export interface ProfileForm {
+  first: FormControl<string>;
+  last: FormControl<string>;
+  gender: FormControl<string>;
+  genderOther: FormControl<string>;
+}
+
 @Component({
   selector: 'app-profile',
   standalone: true,
@@ -33,7 +40,7 @@ import { TextFieldCvaComponent } from '../text-field-cva/text-field-cva.componen
 export class ProfileComponent {
   @Input() controlKey = '';
 
-  form!: FormGroup;
+  form!: FormGroup<ProfileForm>;
   genderOptions: string[] = [
     'Female',
     'Male',
@@ -59,12 +66,21 @@ export class ProfileComponent {
   ngOnInit(): void {
     this.form = this.fb.group(
       {
-        first: ['b', Validators.required],
-        last: ['c', Validators.required],
-        gender: ['Other', Validators.required],
-        genderOther: [''],
+        first: this.fb.nonNullable.control('', { validators: Validators.required }),
+        last: this.fb.nonNullable.control('', { validators: Validators.required }),
+        gender: this.fb.nonNullable.control(
+          '', 
+          { 
+            validators: Validators.required,
+            updateOn: 'change'
+          }),
+        // TODO: Implement conditional validator on genderOther control
+        genderOther: this.fb.nonNullable.control(''),
       },
-      { validators: this.allRequiredFieldsFilled }
+      { 
+        validators: this.allRequiredFieldsFilled,
+        updateOn: 'blur', 
+      }
     );
     this.parentFormGroup.setControl(this.controlKey, this.form);
   }
@@ -78,8 +94,10 @@ export class ProfileComponent {
     this.form.updateValueAndValidity();
   }
 
+  // Note: Parameter type must be of type AbstractControl as this function will be called with this type
+  // and cannot automatically downcast to a subtype - will show error when calling fb.group(). 
   allRequiredFieldsFilled(control: AbstractControl): ValidationErrors | null {
-    const controlValue = control.value;
+    const controlValue = (control as FormGroup<ProfileForm>).value;
     let isValid;
     if (controlValue) {
       isValid =

--- a/src/app/components/text-field-cva/text-field-cva.component.html
+++ b/src/app/components/text-field-cva/text-field-cva.component.html
@@ -8,14 +8,14 @@
     [disabled]="disabled"
     class="form-control"
     [ngClass]="{
-      'is-invalid': control && control.touched && !control.valid,
-      'is-valid': control && control.touched && control.valid
+      'is-invalid': control && control.touched && !control.valid && !disabled,
+      'is-valid': control && control.touched && control.valid && !disabled
     }"
   />
   <div
     class="text-danger"
     [ngClass]="
-      control && control.touched && !control.valid ? 'visible' : 'invisible'
+      control && control.touched && !control.valid && !disabled ? 'visible' : 'invisible'
     "
   >
     This field is required!

--- a/src/app/form-wizard/form-wizard.component..ts
+++ b/src/app/form-wizard/form-wizard.component..ts
@@ -1,0 +1,78 @@
+import { Component, DoCheck, OnInit } from '@angular/core';
+import 'zone.js';
+import {
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { TextFieldCvaComponent } from '../components/text-field-cva/text-field-cva.component';
+import { ProfileComponent, ProfileForm } from '../components/profile/profile.component';
+
+@Component({
+  selector: 'form-wizard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TextFieldCvaComponent,
+    ProfileComponent,
+  ],
+  templateUrl: './form-wizard.component.html',
+})
+export class FormWizardComponent implements OnInit, DoCheck {
+  form = this.fb.group({
+    issues: this.fb.group({}),
+    parties: this.fb.group({}),
+  });
+  lifecycleTicks: number = 0;
+
+  constructor(public fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    console.log(this.form);
+    
+  }
+
+  ngDoCheck() {
+    console.log(++this.lifecycleTicks);
+  }
+
+  onSubmit(form: FormGroup): void {
+    // 1. For all updateOn options, updateValueAndValidity is not called internally by any of the events unless the value in the input (view) has actually changed from the input in the model.
+    //   - For updateOn: 'submit', I just need to bind [formGroup] to the root form for the submit button click to update all nested form controls with this option
+    //   - https://stackoverflow.com/questions/57452687/angular-6-reactive-forms-updateon-submit-is-not-updating-value-after-submit	
+    //   - Note: Listening to ngSubmit or submit event in the template is not required.
+    // 2. On the other hand, changing the value programmatically using setValue DOES call updateValueAndValidity internally
+    //   - BUT, setValue does not change TOUCHED or PRISTINE status (seems like these can only be changed by events in the view) - touched changed onblur, pristine changed onchange
+    //   - I think Pristine/Dirty value is updated separately and has no bearing on if updateValueAndValidity is called or how it is called.
+    this.updateFormValueAndValidity(form); // async because of event emitter
+    form.markAllAsTouched(); // async because of event emitter
+    console.log('Marked form as touched:', form);
+
+    if (form.valid) {
+      // not triggered on the first time because emitted events to update parent form are async
+      alert(form.value);
+    }
+  }
+
+  private updateFormValueAndValidity(
+    formControls: FormGroup | FormArray
+  ): void {
+    for (const control of Object.values(formControls.controls)) {
+      if (control instanceof FormGroup || control instanceof FormArray) {
+        this.updateFormValueAndValidity(control);
+      } else {
+        control.updateValueAndValidity();
+        // TODO: Set all isEligibilityChecked FormControls to true to show the Eligibility badge for all issue forms
+      }
+    }
+  }
+
+  onMarkAllAsTouched(formGroup: FormGroup) {
+    formGroup.markAllAsTouched(); // async because of event emitter
+    console.log('Marked form as touched:', formGroup);
+  }
+}

--- a/src/app/form-wizard/form-wizard.component.html
+++ b/src/app/form-wizard/form-wizard.component.html
@@ -1,0 +1,58 @@
+<h2 class="display-6">
+  <b>Form Wizard</b>
+</h2>
+
+<form
+  [formGroup]="form"
+  (ngSubmit)="onSubmit(form)"
+  class="mt-5 border border-5 pt-3 pb-3 container needs-validation"
+  novalidate
+>
+<!-- [ngClass]="{
+  'border-danger': form.touched && !form.valid,
+  'border-success': form.touched && form.valid
+}" -->
+  <div class="text-secondary">
+    <b>Form Status:</b>
+    <span
+      [ngClass]="{
+        'text-danger': form.touched && !form.valid && !form.disabled,
+        'text-success': form.touched && form.valid && !form.disabled
+      }"
+    >
+      <!-- All value and validation statuses are updated when the form is created -->
+      {{ form.status }}
+    </span>
+
+    {{ form.touched ? 'touched' : 'untouched' }}
+    {{ form.dirty ? 'dirty' : 'pristine' }}
+    <!-- <button
+      type="button"
+      (click)="onMarkAllAsTouched(form)"
+      class="btn btn-primary"
+    >
+      Mark All Touched
+    </button> -->
+    <br />
+    <b>Form Value: </b>
+    <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
+    <!-- {{ form.value | json }} -->
+    <br /><b>Form Errors: </b>
+    <!-- Note that even though a form group aggregates validity status of all child AbstractControls, it does not aggregate their errors. It only shows errors defined at its own form group level -->
+    {{ form.errors | json }}
+  </div>
+
+  <!-- <app-text-field-cva formControlName="testInput"></app-text-field-cva> -->
+  <h4 class="mt-3">Additional Information</h4>
+  <app-profile controlKey="issues"></app-profile>
+
+  <div class="d-flex justify-content-between">
+    <button type="submit" style="width: 90px" class="btn btn-primary mt-3">
+      @if (form.pending) {
+      <div class="spinner-border spinner-border-sm text-light" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      } @else { Continue }
+    </button>
+  </div>
+</form>

--- a/src/app/form-wizard/requirements.md
+++ b/src/app/form-wizard/requirements.md
@@ -1,0 +1,4 @@
+# Create Form Wizard design (e.g. Form Projection, validation) with reusable form groups (wizard steps) and state management (form builder service)
+1. Form wizard stepper and Form projection with transclusion and DI - to understand how Material Stepper would do it so that we can integrate forms projection into the wizard/stepper
+2. Reusable form groups with DI - need to apply this design pattern across all subforms
+3. Scalable form state management with Facade services to be used with question node form builder design and make refactoring to NGRX easier for example

--- a/src/app/long-form-1/long-form-1.component.html
+++ b/src/app/long-form-1/long-form-1.component.html
@@ -103,7 +103,7 @@
 
           <div class="col mb-3">
             <label class="fw-bold">Is Eligible?</label>
-            <select formControlName="isEligible" class="form-control mb-3"
+            <select formControlName="isEligible" class="form-select mb-3"
               [ngClass]="{
                 'is-invalid': issueForm.get('isEligible') && 
                               (issueForm.get('isEligible')!.touched || issueForm.get('isEligible')!.dirty) && 
@@ -173,8 +173,8 @@
             "
             class="text-danger"
           >
-            @if ( issueForm.hasError('issueType') ) {
-            {{ issueForm.getError('issueType') }}
+            @if ( issueForm.hasError('requiredFields') ) {
+            {{ issueForm.getError('requiredFields') }}
             } @else if ( issueForm.hasError('issueEligibility') ) {
             {{ issueForm.getError('issueEligibility') }}
             } @else {

--- a/src/app/long-form-1/long-form-1.component.ts
+++ b/src/app/long-form-1/long-form-1.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { TextFieldCvaComponent } from '../components/text-field-cva/text-field-cva.component';
-import { issueEligibilityValidator, issueTypeValidator } from './validators';
+import { eligibilityValidator, requiredEligibilityFieldsValidator } from './validators';
 
 @Component({
   selector: 'app-long-form-1',
@@ -66,8 +66,8 @@ export class LongForm1Component implements OnInit, DoCheck {
           // }),
         },
         {
-          validators: [issueTypeValidator],
-          asyncValidators: [issueEligibilityValidator],
+          validators: [requiredEligibilityFieldsValidator],
+          asyncValidators: [eligibilityValidator],
         }
       )
     );

--- a/src/app/long-form-1/validators.ts
+++ b/src/app/long-form-1/validators.ts
@@ -7,51 +7,86 @@ import {
 } from '@angular/forms';
 import { Observable, catchError, delay, map, of } from 'rxjs';
 
-export function issueTypeValidator(
+export function requiredEligibilityFieldsValidator(
   control: AbstractControl
 ): ValidationErrors | null {
-  // if (!control.parent) {
-  //   return null;
+  // const parentForm = control.parent as FormGroup<IssueForm>;
+  // if (!parentForm) {
+  //   return of(null);
   // }
-  // const issueTypeValue = (control.parent.get('issueType') as FormControl).value;
-  const issueTypeValue = (control.get('issueType') as FormControl).value;
-  return issueTypeValue && issueTypeValue.length < 5
-    ? { issueType: `${issueTypeValue} is not a valid issue type.` }
+
+  const issueType = (control.get('issueType') as FormControl<string>).value;
+  const isEligible = (control.get('isEligible') as FormControl<boolean | null>).value; 
+  return !issueType || isEligible === null
+    ? { requiredFields: `Fill in all required fields.` }
     : null;
 }
 
-export function issueEligibilityValidator(
+export function eligibilityValidator(
   control: AbstractControl
 ): Observable<ValidationErrors | null> {
-  // if (!control.parent) {
+  // const parentForm = control.parent as FormGroup<IssueForm>;
+  // if (!parentForm) {
   //   return of(null);
   // }
-  // const issueTypeValue = (control.parent.get('issueType') as FormControl).value;
-  const issueTypeValue = (control.get('issueType') as FormControl).value;
-  return of(issueTypeValue).pipe(
+
+  const isEligible = (control.get('isEligible') as FormControl<boolean | null>).value;
+  return of(isEligible).pipe(
     delay(1000),
-    map((issueTypeValue) =>
-      issueTypeValue !== 'Request for Records'
-        ? {
-            issueEligibility: `This issue of type ${issueTypeValue} is not eligible.`,
-          }
+    map((isEligible) =>
+      !isEligible
+        ? { issueEligibility: `This issue is not eligible.` }
         : null
     ),
     catchError(() => of(null))
   );
 }
 
-export function allRequiredFieldsFilled(
-  control: AbstractControl
-): ValidationErrors | null {
-  const controlValue = control.value;
-  let isValid;
-  if (controlValue) {
-    isValid =
-      controlValue.first &&
-      controlValue.last &&
-      controlValue.gender &&
-      (controlValue.gender !== 'Other' || controlValue.genderOther);
-  }
-  return isValid ? null : { allRequired: true };
-}
+// export function issueTypeValidator(
+//   control: AbstractControl
+// ): ValidationErrors | null {
+//   // if (!control.parent) {
+//   //   return null;
+//   // }
+//   // const issueTypeValue = (control.parent.get('issueType') as FormControl).value;
+//   const issueTypeValue = (control.get('issueType') as FormControl).value;
+//   return issueTypeValue && issueTypeValue.length < 5
+//     ? { issueType: `${issueTypeValue} is not a valid issue type.` }
+//     : null;
+// }
+
+// export function issueEligibilityValidator(
+//   control: AbstractControl
+// ): Observable<ValidationErrors | null> {
+//   // if (!control.parent) {
+//   //   return of(null);
+//   // }
+//   // const issueTypeValue = (control.parent.get('issueType') as FormControl).value;
+//   const issueTypeValue = (control.get('issueType') as FormControl).value;
+//   return of(issueTypeValue).pipe(
+//     delay(1000),
+//     map((issueTypeValue) =>
+//       issueTypeValue !== 'Request for Records'
+//         ? {
+//             issueEligibility: `This issue of type ${issueTypeValue} is not eligible.`,
+//           }
+//         : null
+//     ),
+//     catchError(() => of(null))
+//   );
+// }
+
+// export function allRequiredFieldsFilled(
+//   control: AbstractControl
+// ): ValidationErrors | null {
+//   const controlValue = control.value;
+//   let isValid;
+//   if (controlValue) {
+//     isValid =
+//       controlValue.first &&
+//       controlValue.last &&
+//       controlValue.gender &&
+//       (controlValue.gender !== 'Other' || controlValue.genderOther);
+//   }
+//   return isValid ? null : { allRequired: true };
+// }

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -6,18 +6,18 @@
   [formGroup]="form"
   (ngSubmit)="onSubmit(form)"
   class="mt-5 border border-5 pt-3 pb-3 container needs-validation"
-  [ngClass]="{
-    'border-danger': form.touched && !form.valid,
-    'border-success': form.touched && form.valid
-  }"
   novalidate
 >
+<!-- [ngClass]="{
+  'border-danger': form.touched && !form.valid,
+  'border-success': form.touched && form.valid
+}" -->
   <div class="text-secondary">
     <b>Form Status:</b>
     <span
       [ngClass]="{
-        'text-danger': form.touched && !form.valid,
-        'text-success': form.touched && form.valid
+        'text-danger': form.touched && !form.valid && !form.disabled,
+        'text-success': form.touched && form.valid && !form.disabled
       }"
     >
       <!-- All value and validation statuses are updated when the form is created -->
@@ -26,13 +26,13 @@
 
     {{ form.touched ? 'touched' : 'untouched' }}
     {{ form.dirty ? 'dirty' : 'pristine' }}
-    <button
+    <!-- <button
       type="button"
       (click)="onMarkAllAsTouched(form)"
       class="btn btn-primary"
     >
       Mark All Touched
-    </button>
+    </button> -->
     <br />
     <b>Form Value: </b>
     <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
@@ -50,12 +50,12 @@
         class="mt-3 border border-3 pt-3 pb-3 container"
         [formGroup]="issueForm"
         (ngSubmit)="onSubmit(issueForm)"
-        [ngClass]="{
-          'border-danger': issueForm.touched && !issueForm.valid,
-          'border-success': issueForm.touched && issueForm.valid
-        }"
       >
-        <!-- Note the border formatting is based on the form validity which is independent of the Eligibility when isEligibilityChecked = false -->
+      <!-- [ngClass]="{
+        'border-danger': issueForm.touched && !issueForm.valid,
+        'border-success': issueForm.touched && issueForm.valid
+      }" -->
+        <!-- Note the border formatting is based on the form validity which does not align with Eligibility when isEligibilityChecked = false -->
         <!-- You need both form green border and eligible badge to show that form is both valid and eligible. -->
         <header class="row">
           <h3 style="height: 47px" class="display-6">
@@ -74,8 +74,8 @@
             <b>Status:</b>
             <span
               [ngClass]="{
-                'text-danger': issueForm.touched && !issueForm.valid,
-                'text-success': issueForm.touched && issueForm.valid
+                'text-danger': issueForm.touched && !issueForm.valid && !issueForm.disabled,
+                'text-success': issueForm.touched && issueForm.valid && !issueForm.disabled
               }"
             >
               <!-- All value and validation statuses are updated when the issueForm is created -->
@@ -83,15 +83,15 @@
             </span>
             {{ issueForm.touched ? 'touched' : 'untouched' }}
             {{ issueForm.dirty ? 'dirty' : 'pristine' }}
-            <button
+            <!-- <button
               type="button"
               (click)="onMarkAllAsTouched(issueForm)"
               class="btn btn-primary"
             >
               Mark All Touched
-            </button>
-            <br />
-            <b>Value: </b>
+            </button> -->
+            <!-- <br /> -->
+            <!-- <b>Value: </b> -->
             <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
             <!-- {{ issueForm.value | json }} -->
             <br><b>Eligibility Validator Errors:</b> 
@@ -112,6 +112,20 @@
               <span class="badge bg-danger ms-3">Ineligible</span>
             }
           </h4>
+          <div class="text-secondary">
+            <b>Subform Status:</b>
+            <span
+              [ngClass]="{
+                'text-danger': issueForm.get('eligibility')?.touched && !issueForm.get('eligibility')?.valid && !issueForm.get('eligibility')?.disabled,
+                'text-success': issueForm.get('eligibility')?.touched && issueForm.get('eligibility')?.valid && !issueForm.get('eligibility')?.disabled
+              }"
+            >
+              <!-- All value and validation statuses are updated when the issueForm is created -->
+              {{ issueForm.get('eligibility')?.status }}
+            </span>
+            {{ issueForm.get('eligibility')?.touched ? 'touched' : 'untouched' }}
+            {{ issueForm.get('eligibility')?.dirty ? 'dirty' : 'pristine' }}
+          </div>
           <!-- <div class="col text-secondary mb-3">
             <b>Eligibility Validator Errors:</b> 
             <br />{{ issueForm.get('eligibilityValidators')?.errors | json }}
@@ -124,10 +138,10 @@
               [ngClass]="{
                 'is-invalid': issueForm.get('eligibility.isEligible') && 
                               (issueForm.get('eligibility.isEligible')!.touched || issueForm.get('eligibility.isEligible')!.dirty) && 
-                              !issueForm.get('eligibility.isEligible')!.valid,
+                              !issueForm.get('eligibility.isEligible')!.valid && !issueForm.get('eligibility.isEligible')!.disabled,
                 'is-valid': issueForm.get('eligibility.isEligible') && 
                             (issueForm.get('eligibility.isEligible')!.touched || issueForm.get('eligibility.isEligible')!.dirty) && 
-                            issueForm.get('eligibility.isEligible')!.valid,
+                            issueForm.get('eligibility.isEligible')!.valid && !issueForm.get('eligibility.isEligible')!.disabled,
               }"
             >
               <option disabled [ngValue]="null">Select an Option...</option>
@@ -139,7 +153,8 @@
               [ngClass]="
                 issueForm.get('eligibility.isEligible') && 
                 issueForm.get('eligibility.isEligible')!.touched && 
-                !issueForm.get('eligibility.isEligible')!.valid 
+                !issueForm.get('eligibility.isEligible')!.valid &&
+                !issueForm.get('eligibility.isEligible')!.disabled
                   ? 'visible' 
                   : 'invisible'
               "
@@ -169,24 +184,35 @@
           </div>
 
           <div>
-            <button
-              type="button"
-              style="width: 136px"
-              class="btn btn-primary mt-3"
-              (click)="onCheckEligibility(issueForm)"
-            >
-              @if (issueForm.pending) {
-                <div
-                  class="spinner-border spinner-border-sm text-light"
-                  role="status"
-                >
-                  <span class="visually-hidden">Loading...</span>
-                </div>
-              } 
-              @else { 
-                <span>Check Eligibility</span> 
-              }
-            </button>
+            @if(!shouldShowAsEligible(issueForm)) {
+              <button
+                type="button"
+                style="width: 136px"
+                class="btn btn-primary mt-3"
+                (click)="onCheckEligibility(issueForm)"
+              >
+                @if (issueForm.pending) {
+                  <div
+                    class="spinner-border spinner-border-sm text-light"
+                    role="status"
+                  >
+                    <span class="visually-hidden">Loading...</span>
+                  </div>
+                } 
+                @else { 
+                  <span>Check Eligibility</span> 
+                }
+              </button>
+            }
+            @else {
+              <button
+                type="button"
+                class="btn btn-primary mt-3"
+                (click)="onEditInformation(issueForm)"
+              >
+                Edit Information
+              </button>
+            }
           </div>
           <!-- <div
             [ngClass]="

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -94,13 +94,15 @@
             <b>Issue Value: </b>
             <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
             {{ issueForm.value | json }}
-            <br /><b>Eligibility Check Errors:</b> 
-            <br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
           </div>
         </header>
 
         <section formGroupName="eligibility" class="row mt-3">
           <h3 class="display-6">Eligibility Questions</h3>
+          <div class="col text-secondary mb-3">
+            <b>Eligibility Validator Errors:</b> 
+            <br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
+          </div>
           <app-text-field-cva formControlName="issueType"></app-text-field-cva>
           
           <div class="col mb-3">

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -36,7 +36,7 @@
     <br />
     <b>Form Value: </b>
     <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
-    {{ form.value | json }}
+    <!-- {{ form.value | json }} -->
     <br /><b>Form Errors: </b>
     <!-- Note that even though a form group aggregates validity status of all child AbstractControls, it does not aggregate their errors. It only shows errors defined at its own form group level -->
     {{ form.errors | json }}
@@ -71,7 +71,7 @@
             } -->
           </h3>
           <div class="text-secondary">
-            <b>Issue Status:</b>
+            <b>Status:</b>
             <span
               [ngClass]="{
                 'text-danger': issueForm.touched && !issueForm.valid,
@@ -91,9 +91,9 @@
               Mark All Touched
             </button>
             <br />
-            <b>Issue Value: </b>
+            <b>Value: </b>
             <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
-            {{ issueForm.value | json }}
+            <!-- {{ issueForm.value | json }} -->
             <br><b>Eligibility Validator Errors:</b> 
             <br>{{ issueForm.get('eligibilityValidators')?.errors | json }}
           </div>

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -202,12 +202,18 @@
           </div> -->
         </section>
 
-        @if (issueForm.get('shouldShowProfileForm')?.value) {
+        <!-- @if (issueForm.get('shouldShowProfileForm')?.value) {
           <section class="row mt-3">
             <h4>Additional Information</h4>
             <app-profile controlKey="profile"></app-profile>
           </section>
-        }
+        } -->
+        <section class="row mt-3"
+          [ngClass]="{ 'd-none': !issueForm.get('shouldShowProfileForm')?.value }"
+        >
+          <h4>Additional Information</h4>
+          <app-profile controlKey="profile"></app-profile>
+        </section>
       </form>
     </ng-container>
   </ng-container>

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -58,17 +58,8 @@
         <!-- Note the border formatting is based on the form validity which is independent of the Eligibility when isEligibilityChecked = false -->
         <!-- You need both form green border and eligible badge to show that form is both valid and eligible. -->
         <header class="row">
-          <h3 style="height: 47px" class="display-6">
+          <h3 class="display-6">
             Issue {{ i + 1 }}
-            @if (issueForm.pending) {
-              <div class="ms-3 spinner-border text-primary" role="status">
-                <span class="visually-hidden">Loading...</span>
-              </div>
-            } @else if (shouldShowAsEligible(issueForm)) {
-              <span class="badge bg-success ms-3">Eligible</span>
-            } @else if (shouldShowAsIneligible(issueForm)) {
-              <span class="badge bg-danger ms-3">Ineligible</span>
-            }
           </h3>
           <div class="text-secondary">
             <b>Issue Status:</b>
@@ -98,7 +89,18 @@
         </header>
 
         <section formGroupName="eligibility" class="row mt-3">
-          <h3 class="display-6">Eligibility Questions</h3>
+          <h4 style="height: 30px">
+            Eligibility Questions
+            @if (issueForm.pending) {
+              <div class="ms-3 spinner-border spinner-border-sm text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+              </div>
+            } @else if (shouldShowAsEligible(issueForm)) {
+              <span class="badge bg-success ms-3">Eligible</span>
+            } @else if (shouldShowAsIneligible(issueForm)) {
+              <span class="badge bg-danger ms-3">Ineligible</span>
+            }
+          </h4>
           <div class="col text-secondary mb-3">
             <b>Eligibility Validator Errors:</b> 
             <br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
@@ -146,9 +148,9 @@
           >
             @if (
               shouldShowAsIneligible(issueForm) &&
-              issueForm.get('eligibility.eligibilityValidators')?.hasError('issueType')
+              issueForm.get('eligibility.eligibilityValidators')?.hasError('requiredFields')
             ) {
-              <span>{{ issueForm.get('eligibility.eligibilityValidators')?.getError('issueType') }}</span>
+              <span>{{ issueForm.get('eligibility.eligibilityValidators')?.getError('requiredFields') }}</span>
             } 
             @else if (
               shouldShowAsIneligible(issueForm) &&
@@ -200,7 +202,7 @@
         </section>
 
         <section class="row mt-3">
-          <h3 class="display-6">Additional Information</h3>
+          <h4>Additional Information</h4>
           <app-profile controlKey="profile"></app-profile>
         </section>
       </form>

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -37,8 +37,9 @@
     <b>Form Value: </b>
     <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
     {{ form.value | json }}
+    <br /><b>Form Errors: </b>
     <!-- Note that even though a form group aggregates validity status of all child AbstractControls, it does not aggregate their errors. It only shows errors defined at its own form group level -->
-    @if (!form.valid) {<br /><b>Form Errors: </b> {{ form.errors | json }}}
+    {{ form.errors | json }}
   </div>
 
   <!-- <app-text-field-cva formControlName="testInput"></app-text-field-cva> -->
@@ -93,14 +94,13 @@
             <b>Issue Value: </b>
             <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
             {{ issueForm.value | json }}
-            <!-- Note that even though a issueForm group aggregates validity status of all child AbstractControls, it does not aggregate their errors. It only shows errors defined at its own form group level -->
-            @if (!issueForm.get('eligibility.eligibilityValidators')?.valid) {
-              <br /><b>Eligibility Check Errors:</b><br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
-            }
+            <br /><b>Eligibility Check Errors:</b> 
+            <br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
           </div>
         </header>
 
         <section formGroupName="eligibility" class="row mt-3">
+          <h3 class="display-6">Eligibility Questions</h3>
           <app-text-field-cva formControlName="issueType"></app-text-field-cva>
           
           <div class="col mb-3">

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -58,8 +58,17 @@
         <!-- Note the border formatting is based on the form validity which is independent of the Eligibility when isEligibilityChecked = false -->
         <!-- You need both form green border and eligible badge to show that form is both valid and eligible. -->
         <header class="row">
-          <h3 class="display-6">
+          <h3 style="height: 47px" class="display-6">
             Issue {{ i + 1 }}
+            <!-- @if (issueForm.pending) {
+              <div class="ms-3 spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+              </div>
+            } @else if (shouldShowAsEligible(issueForm)) {
+              <span class="badge bg-success ms-3">Eligible</span>
+            } @else if (shouldShowAsIneligible(issueForm)) {
+              <span class="badge bg-danger ms-3">Ineligible</span>
+            } -->
           </h3>
           <div class="text-secondary">
             <b>Issue Status:</b>
@@ -137,15 +146,7 @@
             </div>
           </div>
           
-          <div
-            [ngClass]="
-              issueForm.get('eligibilityValidators')?.touched &&
-              !issueForm.get('eligibilityValidators')?.valid 
-                ? 'visible' 
-                : 'invisible'
-            "
-            class="text-danger"
-          >
+          <div class="text-danger">
             @if (
               shouldShowAsIneligible(issueForm) &&
               issueForm.get('eligibilityValidators')?.hasError('requiredFields')
@@ -201,11 +202,11 @@
           </div> -->
         </section>
 
-        <section class="row mt-3">
-          <h4>Additional Information</h4>
-          <app-profile controlKey="profile"></app-profile>
-        </section>
-      </form>
+          <section class="row mt-3">
+            <h4>Additional Information</h4>
+            <app-profile controlKey="profile"></app-profile>
+          </section>
+              </form>
     </ng-container>
   </ng-container>
 

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -214,7 +214,9 @@
           [ngClass]="{ 'd-none': !issueForm.get('shouldShowProfileForm')?.value }"
         >
           <h4>Additional Information</h4>
-          <app-profile controlKey="profile"></app-profile>
+          @if(issueForm.get('shouldShowProfileForm')?.value) {
+            <app-profile controlKey="profile"></app-profile>
+          }
         </section>
       </form>
     </ng-container>

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -103,7 +103,7 @@
           </h4>
           <div class="col text-secondary mb-3">
             <b>Eligibility Validator Errors:</b> 
-            <br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
+            <br />{{ issueForm.get('eligibilityValidators')?.errors | json }}
           </div>
           <app-text-field-cva formControlName="issueType"></app-text-field-cva>
           
@@ -139,8 +139,8 @@
           
           <div
             [ngClass]="
-              issueForm.get('eligibility.eligibilityValidators')?.touched &&
-              !issueForm.get('eligibility.eligibilityValidators')?.valid 
+              issueForm.get('eligibilityValidators')?.touched &&
+              !issueForm.get('eligibilityValidators')?.valid 
                 ? 'visible' 
                 : 'invisible'
             "
@@ -148,16 +148,16 @@
           >
             @if (
               shouldShowAsIneligible(issueForm) &&
-              issueForm.get('eligibility.eligibilityValidators')?.hasError('requiredFields')
+              issueForm.get('eligibilityValidators')?.hasError('requiredFields')
             ) {
-              <span>{{ issueForm.get('eligibility.eligibilityValidators')?.getError('requiredFields') }}</span>
+              <span>{{ issueForm.get('eligibilityValidators')?.getError('requiredFields') }}</span>
             } 
             @else if (
               shouldShowAsIneligible(issueForm) &&
-              issueForm.get('eligibility.eligibilityValidators')?.hasError('issueEligibility')
+              issueForm.get('eligibilityValidators')?.hasError('issueEligibility')
             ) {
               <span>
-                {{issueForm.get('eligibility.eligibilityValidators')?.getError('issueEligibility')}}
+                {{issueForm.get('eligibilityValidators')?.getError('issueEligibility')}}
               </span>
             } 
             @else {

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -202,11 +202,13 @@
           </div> -->
         </section>
 
+        @if (issueForm.get('shouldShowProfileForm')?.value) {
           <section class="row mt-3">
             <h4>Additional Information</h4>
             <app-profile controlKey="profile"></app-profile>
           </section>
-              </form>
+        }
+      </form>
     </ng-container>
   </ng-container>
 

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -94,25 +94,25 @@
             <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
             {{ issueForm.value | json }}
             <!-- Note that even though a issueForm group aggregates validity status of all child AbstractControls, it does not aggregate their errors. It only shows errors defined at its own form group level -->
-            @if (!issueForm.get('eligibilityValidators')?.valid) {
-              <br /><b>Eligibility Check Errors:</b><br />{{ issueForm.get('eligibilityValidators')?.errors | json }}
+            @if (!issueForm.get('eligibility.eligibilityValidators')?.valid) {
+              <br /><b>Eligibility Check Errors:</b><br />{{ issueForm.get('eligibility.eligibilityValidators')?.errors | json }}
             }
           </div>
         </header>
 
-        <div class="row mt-3">
+        <section formGroupName="eligibility" class="row mt-3">
           <app-text-field-cva formControlName="issueType"></app-text-field-cva>
           
           <div class="col mb-3">
             <label class="fw-bold">Is Eligible?</label>
-            <select formControlName="isEligible" class="form-control mb-3"
+            <select formControlName="isEligible" class="form-select"
               [ngClass]="{
-                'is-invalid': issueForm.get('isEligible') && 
-                              (issueForm.get('isEligible')!.touched || issueForm.get('isEligible')!.dirty) && 
-                              !issueForm.get('isEligible')!.valid,
-                'is-valid': issueForm.get('isEligible') && 
-                            (issueForm.get('isEligible')!.touched || issueForm.get('isEligible')!.dirty) && 
-                            issueForm.get('isEligible')!.valid,
+                'is-invalid': issueForm.get('eligibility.isEligible') && 
+                              (issueForm.get('eligibility.isEligible')!.touched || issueForm.get('eligibility.isEligible')!.dirty) && 
+                              !issueForm.get('eligibility.isEligible')!.valid,
+                'is-valid': issueForm.get('eligibility.isEligible') && 
+                            (issueForm.get('eligibility.isEligible')!.touched || issueForm.get('eligibility.isEligible')!.dirty) && 
+                            issueForm.get('eligibility.isEligible')!.valid,
               }"
             >
               <option disabled [ngValue]="null">Select an Option...</option>
@@ -122,9 +122,9 @@
             <div
               class="text-danger"
               [ngClass]="
-                issueForm.get('isEligible') && 
-                issueForm.get('isEligible')!.touched && 
-                !issueForm.get('isEligible')!.valid 
+                issueForm.get('eligibility.isEligible') && 
+                issueForm.get('eligibility.isEligible')!.touched && 
+                !issueForm.get('eligibility.isEligible')!.valid 
                   ? 'visible' 
                   : 'invisible'
               "
@@ -135,8 +135,8 @@
           
           <div
             [ngClass]="
-              issueForm.get('eligibilityValidators')?.touched &&
-              !issueForm.get('eligibilityValidators')?.valid 
+              issueForm.get('eligibility.eligibilityValidators')?.touched &&
+              !issueForm.get('eligibility.eligibilityValidators')?.valid 
                 ? 'visible' 
                 : 'invisible'
             "
@@ -144,16 +144,16 @@
           >
             @if (
               shouldShowAsIneligible(issueForm) &&
-              issueForm.get('eligibilityValidators')?.hasError('issueType')
+              issueForm.get('eligibility.eligibilityValidators')?.hasError('issueType')
             ) {
-              <span>{{ issueForm.get('eligibilityValidators')?.getError('issueType') }}</span>
+              <span>{{ issueForm.get('eligibility.eligibilityValidators')?.getError('issueType') }}</span>
             } 
             @else if (
               shouldShowAsIneligible(issueForm) &&
-              issueForm.get('eligibilityValidators')?.hasError('issueEligibility')
+              issueForm.get('eligibility.eligibilityValidators')?.hasError('issueEligibility')
             ) {
               <span>
-                {{issueForm.get('eligibilityValidators')?.getError('issueEligibility')}}
+                {{issueForm.get('eligibility.eligibilityValidators')?.getError('issueEligibility')}}
               </span>
             } 
             @else {
@@ -195,12 +195,12 @@
             <span class="invisible">placeholder</span>
             }
           </div> -->
-        </div>
+        </section>
 
-        <!-- <section>
-          <h6 class="display-6">Eligibility Questions</h6>
-          <app-profile controlKey="eligibility"></app-profile>
-        </section> -->
+        <section class="row mt-3">
+          <h3 class="display-6">Additional Information</h3>
+          <app-profile controlKey="profile"></app-profile>
+        </section>
       </form>
     </ng-container>
   </ng-container>
@@ -237,7 +237,7 @@
       state for overall form validity such as a green border.
     </li>
     <li>
-      <b>UX Approach 2:</b>To only show issue eligibility based on overall form validity - only updated on Check Eligibility click and Done click, 
+      <b>UX Approach 2:</b> To only show issue eligibility based on overall form validity - only updated on Check Eligibility click and Done click, 
       need extra state variable to track hiding of the form validity when it's out-of-date (out of sync with inputs).
       Although UX wants to show the feedback once the eligibility questions have been filled in which would be hard 
       because the overall form would be invalid based on the required additional info questions.

--- a/src/app/long-form-2/long-form-2.component.html
+++ b/src/app/long-form-2/long-form-2.component.html
@@ -94,6 +94,8 @@
             <b>Issue Value: </b>
             <!-- The following causes ExpressionChangedAfterItHasBeenCheckedError since child component modifies parent's state with setControl -->
             {{ issueForm.value | json }}
+            <br><b>Eligibility Validator Errors:</b> 
+            <br>{{ issueForm.get('eligibilityValidators')?.errors | json }}
           </div>
         </header>
 
@@ -110,10 +112,10 @@
               <span class="badge bg-danger ms-3">Ineligible</span>
             }
           </h4>
-          <div class="col text-secondary mb-3">
+          <!-- <div class="col text-secondary mb-3">
             <b>Eligibility Validator Errors:</b> 
             <br />{{ issueForm.get('eligibilityValidators')?.errors | json }}
-          </div>
+          </div> -->
           <app-text-field-cva formControlName="issueType"></app-text-field-cva>
           
           <div class="col mb-3">
@@ -246,11 +248,11 @@
   </p>
   <ul>
     <li>
-      <b>UX Approach 1:</b> Make it clear that eligibility only applies to the eligibility questions, and there's a different UI
+      <b>UX Option 1:</b> Make it clear that eligibility only applies to the eligibility questions, and there's a different UI
       state for overall form validity such as a green border.
     </li>
     <li>
-      <b>UX Approach 2:</b> To only show issue eligibility based on overall form validity - only updated on Check Eligibility click and Done click, 
+      <b>UX Option 2:</b> To only show issue eligibility based on overall form validity - only updated on Check Eligibility click and Done click, 
       need extra state variable to track hiding of the form validity when it's out-of-date (out of sync with inputs).
       Although UX wants to show the feedback once the eligibility questions have been filled in which would be hard 
       because the overall form would be invalid based on the required additional info questions.

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -133,7 +133,7 @@ export class LongForm2Component implements OnInit, DoCheck {
     console.log('Marked form as touched:', form);
 
     if (form.valid) {
-      // not triggered because updateFormValueAndValidity is async
+      // not triggered on the first time because updateFormValueAndValidity is async
       alert(form.value);
     }
   }

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { TextFieldCvaComponent } from '../components/text-field-cva/text-field-cva.component';
-import { requiredEligibilityFieldsValidator, eligibilityValidator, issueEligibilityValidator, issueTypeValidator } from './validators';
+import { requiredEligibilityFieldsValidator, eligibilityValidator } from './validators';
 import { ProfileComponent, ProfileForm } from '../components/profile/profile.component';
 import { first, tap } from 'rxjs';
 

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -20,8 +20,8 @@ export interface IssueForm {
 }
 
 export interface EligibilityForm {
-  isEligible: FormControl<boolean | null>;
   issueType: FormControl<string>;
+  isEligible: FormControl<boolean | null>;
   eligibilityValidators: FormControl<null>;
   isEligibilityChecked: FormControl<boolean>;
 }
@@ -67,13 +67,13 @@ export class LongForm2Component implements OnInit, DoCheck {
     const newIssue = this.fb.group<IssueForm>({
       eligibility: this.fb.group<EligibilityForm>(
         {
-          isEligible: this.fb.control<boolean | null>(null, {
-            validators: Validators.required,
-            updateOn: 'change'
-          }),
           issueType: this.fb.nonNullable.control<string>('', {
             validators: Validators.required,
             updateOn: 'blur',
+          }),
+          isEligible: this.fb.control<boolean | null>(null, {
+            validators: Validators.required,
+            updateOn: 'change'
           }),
           eligibilityValidators: this.fb.control<null>(null, {
             validators: [requiredEligibilityFieldsValidator],

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -98,6 +98,15 @@ export class LongForm2Component implements OnInit, DoCheck {
       (newIssue.get('isEligibilityChecked') as FormControl).setValue(false)
       console.log(formValue);
     });
+    const subscriptionToShowProfileForm = (newIssue.get('eligibilityValidators') as FormControl)
+      .statusChanges
+      .subscribe(status => {
+        console.log('status:', status);
+        if (status === 'VALID') {
+          (newIssue.get('shouldShowProfileForm') as FormControl).setValue(true);
+          subscriptionToShowProfileForm.unsubscribe();
+        }
+      });
     this.issues.push(newIssue);
     console.log(this.form);
   }
@@ -112,18 +121,6 @@ export class LongForm2Component implements OnInit, DoCheck {
     // if ((issueForm.get('eligibilityValidators') as FormControl).valid) {
     //   (issueForm.get('shouldShowProfileForm') as FormControl).setValue(true);
     // }
-    // Just move this statusChanges subscription to FormGroup instantiation in addIssue
-    if (!(issueForm.get('shouldShowProfileForm') as FormControl<boolean>).value) {
-      (issueForm.get('eligibilityValidators') as FormControl).statusChanges.pipe(
-        first()
-      )
-      .subscribe(status => {
-        console.log('status:', status);
-        if (status === 'VALID') {
-          (issueForm.get('shouldShowProfileForm') as FormControl).setValue(true);
-        }
-      });
-    }
   }
 
   shouldShowAsEligible(issueForm: FormGroup<IssueForm>): boolean {
@@ -141,14 +138,14 @@ export class LongForm2Component implements OnInit, DoCheck {
   onSubmit(form: FormGroup): void {
     // TODO: Set all isEligibilityChecked FormControls to true to show the Eligibility badge for all issue forms
     
-    // Actually, I don't even know if I need to manually call update, 
+    // TODO: Actually, I don't even know if I need to manually call update, 
     // seems like the submit event triggers all updateOn: 'Submit' form controls
     this.updateFormValueAndValidity(form); // async because of event emitter
     form.markAllAsTouched(); // async because of event emitter
     console.log('Marked form as touched:', form);
 
     if (form.valid) {
-      // not triggered on the first time because updateFormValueAndValidity is async
+      // not triggered on the first time because emitted events to update parent form are async
       alert(form.value);
     }
   }

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -11,15 +11,15 @@ import {
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { TextFieldCvaComponent } from '../components/text-field-cva/text-field-cva.component';
-import { allRequiredFieldsFilled, issueEligibilityValidator, issueTypeValidator } from './validators';
+import { requiredEligibilityFieldsValidator, eligibilityValidator, issueEligibilityValidator, issueTypeValidator } from './validators';
 import { ProfileComponent, ProfileForm } from '../components/profile/profile.component';
 
-interface IssueForm {
+export interface IssueForm {
   eligibility: FormGroup<EligibilityForm>;
   profile: FormGroup<ProfileForm | {}>;
 }
 
-interface EligibilityForm {
+export interface EligibilityForm {
   isEligible: FormControl<boolean | null>;
   issueType: FormControl<string>;
   eligibilityValidators: FormControl<null>;
@@ -76,8 +76,8 @@ export class LongForm2Component implements OnInit, DoCheck {
             updateOn: 'blur',
           }),
           eligibilityValidators: this.fb.control<null>(null, {
-            validators: [allRequiredFieldsFilled, issueTypeValidator],
-            asyncValidators: [issueEligibilityValidator], // async validation will only check issueTypeValidator and not sync validators from sibling controls
+            validators: [requiredEligibilityFieldsValidator],
+            asyncValidators: [eligibilityValidator], // async validation will only check issueTypeValidator and not sync validators from sibling controls
             updateOn: 'submit',
           }),
           isEligibilityChecked: this.fb.nonNullable.control<boolean>(false),

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -57,6 +57,8 @@ export class LongForm2Component implements OnInit, DoCheck {
   ngOnInit(): void {
     this.addIssue();
     console.log(this.form);
+    // Why does calling updateFormValueAndValidity without setTimeout only emit the PENDING state?
+    setTimeout(() => this.updateFormValueAndValidity(this.form), 0);
     this.form.valueChanges.subscribe((formValue) => {
       console.log('Form Value OnInit:', formValue);
     });

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -100,11 +100,12 @@ export class LongForm2Component implements OnInit, DoCheck {
   }
 
   onCheckEligibility(issueForm: FormGroup<IssueForm>) {
-    if (issueForm.pending) return;
+    const eligibilityForm = issueForm.get('eligibility') as FormGroup<EligibilityForm>;
+    if (eligibilityForm.pending) return;
 
-    (issueForm.get('eligibility.eligibilityValidators') as FormControl).updateValueAndValidity();
-    (issueForm.get('eligibility.isEligibilityChecked') as FormControl).setValue(true);
-    issueForm.markAllAsTouched();
+    (eligibilityForm.get('eligibilityValidators') as FormControl).updateValueAndValidity();
+    (eligibilityForm.get('isEligibilityChecked') as FormControl).setValue(true);
+    eligibilityForm.markAllAsTouched();
   }
 
   shouldShowAsEligible(issueForm: FormGroup<IssueForm>): boolean {

--- a/src/app/long-form-2/long-form-2.component.ts
+++ b/src/app/long-form-2/long-form-2.component.ts
@@ -56,8 +56,9 @@ export class LongForm2Component implements OnInit, DoCheck {
 
   ngOnInit(): void {
     this.addIssue();
+    console.log(this.form);
     this.form.valueChanges.subscribe((formValue) => {
-      console.log(formValue);
+      console.log('Form Value OnInit:', formValue);
     });
   }
 
@@ -69,10 +70,10 @@ export class LongForm2Component implements OnInit, DoCheck {
     const newIssue = this.fb.group<IssueForm>({
       eligibility: this.fb.group<EligibilityForm>(
         {
-          issueType: this.fb.nonNullable.control<string>('', {
+          issueType: this.fb.nonNullable.control<string>('a', {
             validators: Validators.required,
           }),
-          isEligible: this.fb.control<boolean | null>(null, {
+          isEligible: this.fb.control<boolean | null>(true, {
             validators: Validators.required,
             updateOn: 'change'
           }),
@@ -97,27 +98,32 @@ export class LongForm2Component implements OnInit, DoCheck {
 
     (newIssue.get('eligibility') as FormGroup<EligibilityForm>).valueChanges.subscribe((formValue) => {
       (newIssue.get('isEligibilityChecked') as FormControl).setValue(false)
-      console.log(formValue);
     });
+
+    (newIssue.get('eligibilityValidators') as FormControl)
+      .valueChanges
+      .subscribe(_ => {
+        (newIssue.get('isEligibilityChecked') as FormControl).setValue(true);
+        console.log('Eligibility Validators Updated!');
+      })
+
     const subscriptionToShowProfileForm = (newIssue.get('eligibilityValidators') as FormControl)
       .statusChanges
       .pipe(distinctUntilChanged())
       .subscribe(status => {
-        console.log('status:', status);
+        console.log('Eligibility Status changed to:', status);
         if (status === 'VALID') {
           (newIssue.get('shouldShowProfileForm') as FormControl).setValue(true);
           subscriptionToShowProfileForm.unsubscribe();
         }
       });
     this.issues.push(newIssue);
-    console.log(this.form);
   }
 
   onCheckEligibility(issueForm: FormGroup<IssueForm>) {
     if (issueForm.pending) return;
 
     (issueForm.get('eligibilityValidators') as FormControl).updateValueAndValidity();
-    (issueForm.get('isEligibilityChecked') as FormControl).setValue(true);
     (issueForm.get('eligibility') as FormGroup<EligibilityForm>).markAllAsTouched();
     // Doesn't work because of async validation
     // if ((issueForm.get('eligibilityValidators') as FormControl).valid) {

--- a/src/app/long-form-2/validators.ts
+++ b/src/app/long-form-2/validators.ts
@@ -21,7 +21,6 @@ export function requiredEligibilityFieldsValidator(
   debugger;
   const issueType = (parentForm.get('eligibility.issueType') as FormControl<string>).value;
   const isEligible = (parentForm.get('eligibility.isEligible') as FormControl<boolean | null>).value; 
-
   return !issueType || isEligible === null
     ? { requiredFields: `Fill in all required fields.` }
     : null;
@@ -40,9 +39,7 @@ export function eligibilityValidator(
     delay(1000),
     map((isEligible) =>
       !isEligible
-        ? {
-            issueEligibility: `This issue is not eligible.`,
-          }
+        ? { issueEligibility: `This issue is not eligible.` }
         : null
     ),
     catchError(() => of(null))

--- a/src/app/long-form-2/validators.ts
+++ b/src/app/long-form-2/validators.ts
@@ -7,24 +7,46 @@ import {
   FormGroup,
 } from '@angular/forms';
 import { Observable, catchError, delay, map, of } from 'rxjs';
-import { EligibilityForm } from './long-form-2.component';
+import { EligibilityForm, IssueForm } from './long-form-2.component';
 
 // Note: Parameter type must be of type AbstractControl as this function will be called with this type
 // and cannot automatically downcast to a subtype - will show error when calling fb.group(). 
 export function requiredEligibilityFieldsValidator(
   control: AbstractControl
 ): ValidationErrors | null {
-  const parentForm = control.parent as FormGroup<EligibilityForm>;
+  const parentForm = control.parent as FormGroup<IssueForm>;
   if (!parentForm) {
     return of(null);
   }
-  
-  const issueType = (parentForm.get('issueType') as FormControl<string>).value;
-  const isEligible = (parentForm.get('isEligible') as FormControl<boolean | null>).value; 
+  debugger;
+  const issueType = (parentForm.get('eligibility.issueType') as FormControl<string>).value;
+  const isEligible = (parentForm.get('eligibility.isEligible') as FormControl<boolean | null>).value; 
 
   return !issueType || isEligible === null
     ? { requiredFields: `Fill in all required fields.` }
     : null;
+}
+
+export function eligibilityValidator(
+  control: AbstractControl
+): Observable<ValidationErrors | null> {
+  const parentForm = control.parent as FormGroup<IssueForm>;
+  if (!parentForm) {
+    return of(null);
+  }
+
+  const isEligible = (parentForm.get('eligibility.isEligible') as FormControl<boolean | null>).value;
+  return of(isEligible).pipe(
+    delay(1000),
+    map((isEligible) =>
+      !isEligible
+        ? {
+            issueEligibility: `This issue is not eligible.`,
+          }
+        : null
+    ),
+    catchError(() => of(null))
+  );
 }
 
 export function issueTypeValidator(
@@ -58,28 +80,6 @@ export function issueEligibilityValidator(
       issueTypeValue !== 'Request for Records'
         ? {
             issueEligibility: `This issue of type ${issueTypeValue} is not eligible.`,
-          }
-        : null
-    ),
-    catchError(() => of(null))
-  );
-}
-
-export function eligibilityValidator(
-  control: AbstractControl
-): Observable<ValidationErrors | null> {
-  const parentForm = control.parent as FormGroup<EligibilityForm>;
-  if (!parentForm) {
-    return of(null);
-  }
-
-  const isEligible = (parentForm.get('isEligible') as FormControl<boolean | null>).value;
-  return of(isEligible).pipe(
-    delay(1000),
-    map((isEligible) =>
-      !isEligible
-        ? {
-            issueEligibility: `This issue is not eligible.`,
           }
         : null
     ),

--- a/src/app/long-form-2/validators.ts
+++ b/src/app/long-form-2/validators.ts
@@ -46,40 +46,40 @@ export function eligibilityValidator(
   );
 }
 
-export function issueTypeValidator(
-  control: AbstractControl
-): ValidationErrors | null {
-  const parentForm = control.parent as FormGroup<EligibilityForm>;
-  if (!parentForm) {
-    return of(null);
-  }
+// export function issueTypeValidator(
+//   control: AbstractControl
+// ): ValidationErrors | null {
+//   const parentForm = control.parent as FormGroup<EligibilityForm>;
+//   if (!parentForm) {
+//     return of(null);
+//   }
 
-  const issueType = (parentForm.get('issueType') as FormControl<string>).value;
-  // const issueTypeValue = (control.get('issueType') as FormControl).value;
-  return issueType && issueType.length < 5
-    ? { issueType: `${issueType} is not a valid issue type.` }
-    : null;
-}
+//   const issueType = (parentForm.get('issueType') as FormControl<string>).value;
+//   // const issueTypeValue = (control.get('issueType') as FormControl).value;
+//   return issueType && issueType.length < 5
+//     ? { issueType: `${issueType} is not a valid issue type.` }
+//     : null;
+// }
 
-export function issueEligibilityValidator(
-  control: AbstractControl
-): Observable<ValidationErrors | null> {
-  const parentForm = control.parent as FormGroup<EligibilityForm>;
-  if (!parentForm) {
-    return of(null);
-  }
+// export function issueEligibilityValidator(
+//   control: AbstractControl
+// ): Observable<ValidationErrors | null> {
+//   const parentForm = control.parent as FormGroup<EligibilityForm>;
+//   if (!parentForm) {
+//     return of(null);
+//   }
 
-  const issueType = (parentForm.get('issueType') as FormControl<string>).value;
-  // const issueTypeValue = (control.get('issueType') as FormControl).value;
-  return of(issueType).pipe(
-    delay(1000),
-    map((issueTypeValue) =>
-      issueTypeValue !== 'Request for Records'
-        ? {
-            issueEligibility: `This issue of type ${issueTypeValue} is not eligible.`,
-          }
-        : null
-    ),
-    catchError(() => of(null))
-  );
-}
+//   const issueType = (parentForm.get('issueType') as FormControl<string>).value;
+//   // const issueTypeValue = (control.get('issueType') as FormControl).value;
+//   return of(issueType).pipe(
+//     delay(1000),
+//     map((issueTypeValue) =>
+//       issueTypeValue !== 'Request for Records'
+//         ? {
+//             issueEligibility: `This issue of type ${issueTypeValue} is not eligible.`,
+//           }
+//         : null
+//     ),
+//     catchError(() => of(null))
+//   );
+// }

--- a/src/app/long-form-2/validators.ts
+++ b/src/app/long-form-2/validators.ts
@@ -7,6 +7,8 @@ import {
 } from '@angular/forms';
 import { Observable, catchError, delay, map, of } from 'rxjs';
 
+// Note: Parameter type must be of type AbstractControl as this function will be called with this type
+// and cannot automatically downcast to a subtype - will show error when calling fb.group(). 
 export function allRequiredFieldsFilled(
   control: AbstractControl
 ): ValidationErrors | null {
@@ -53,17 +55,3 @@ export function issueEligibilityValidator(
   );
 }
 
-// export function allRequiredFieldsFilled(
-//   control: AbstractControl
-// ): ValidationErrors | null {
-//   const controlValue = control.value;
-//   let isValid;
-//   if (controlValue) {
-//     isValid =
-//       controlValue.first &&
-//       controlValue.last &&
-//       controlValue.gender &&
-//       (controlValue.gender !== 'Other' || controlValue.genderOther);
-//   }
-//   return isValid ? null : { allRequired: true };
-// }

--- a/src/app/long-form-2/validators.ts
+++ b/src/app/long-form-2/validators.ts
@@ -18,7 +18,7 @@ export function requiredEligibilityFieldsValidator(
   if (!parentForm) {
     return of(null);
   }
-  debugger;
+
   const issueType = (parentForm.get('eligibility.issueType') as FormControl<string>).value;
   const isEligible = (parentForm.get('eligibility.isEligible') as FormControl<boolean | null>).value; 
   return !issueType || isEligible === null


### PR DESCRIPTION
1. Implemented long form with separate manual async validation trigger for nested form group section 1.
2. Implemented enabling and unhiding subsequent nested form group section 2, and disabling and hiding on button click
Note: I did not finish UX approach 1 to separate overall form validity state from the nested form group section validity state. Currently, the overall form validity state becomes VALID when going from nested form group section 2 to section 1 because section 2 gets disabled, which does not match requirements.